### PR TITLE
Fix bug in Process exectution handler in Run class

### DIFF
--- a/src/main/java/com/fundation/webservice/model/Run.java
+++ b/src/main/java/com/fundation/webservice/model/Run.java
@@ -39,6 +39,7 @@ public class Run {
         try {
             Process process = new ProcessBuilder(commandLine).start();
             BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            process.waitFor();
             input.close();
         }
         catch (Exception e) {


### PR DESCRIPTION
Added waitFor() so next operations always wait for the process output.
This is a solution to a bug seen while zipping all output files.